### PR TITLE
[WIP] Improve tasks management

### DIFF
--- a/database/boltdb_test.go
+++ b/database/boltdb_test.go
@@ -232,4 +232,34 @@ func TestBoltDatabase(t *testing.T) {
 		So(tasks, ShouldBeEmpty)
 		So(tasks, ShouldNotBeNil)
 	})
+
+	Convey("List terminated tasks", t, func() {
+		setup()
+		defer teardown()
+		defer db.Close()
+
+		db.Clean()
+		db.PutTask(&types.EremeticTask{
+			ID: "1234",
+			Status: []types.Status{
+				types.Status{
+					Status: types.TaskState_TASK_STAGING,
+					Time:   time.Now().Unix(),
+				},
+				types.Status{
+					Status: types.TaskState_TASK_RUNNING,
+					Time:   time.Now().Unix(),
+				},
+				types.Status{
+					Status: types.TaskState_TASK_FINISHED,
+					Time:   time.Now().Unix(),
+				},
+			},
+		})
+		tasks, err := db.ListTerminatedTasks()
+		So(err, ShouldBeNil)
+		So(tasks, ShouldHaveLength, 1)
+		task := tasks[0]
+		So(task.ID, ShouldEqual, "1234")
+	})
 }

--- a/database/database.go
+++ b/database/database.go
@@ -15,6 +15,8 @@ type TaskDB interface {
 	ReadTask(id string) (types.EremeticTask, error)
 	ReadUnmaskedTask(id string) (types.EremeticTask, error)
 	ListNonTerminalTasks() ([]*types.EremeticTask, error)
+	ListTerminatedTasks() ([]*types.EremeticTask, error)
+	RemoveTask(id string) error
 }
 
 const masking = "*******"

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -126,6 +126,19 @@ func (h Handler) ListRunningTasks() http.HandlerFunc {
 	}
 }
 
+// ListTerminatedTasks returns information about finished tasks in the database,
+// aka history
+func (h Handler) ListTerminatedTasks() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logrus.Debug("Fetching all terminated tasks")
+		tasks, err := h.database.ListTerminatedTasks()
+		if err != nil {
+			handleError(err, w, "Unable to fetch running tasks from the database")
+		}
+		writeJSON(200, tasks, w)
+	}
+}
+
 // IndexHandler returns the index template, or no content.
 func (h Handler) IndexHandler(conf *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/janitor/janitor.go
+++ b/janitor/janitor.go
@@ -1,0 +1,59 @@
+package janitor
+
+import (
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/klarna/eremetic/database"
+)
+
+// Janitor
+type Janitor struct {
+	db              database.TaskDB
+	enabled         bool
+	retentionPeriod int64
+	pause           int64
+}
+
+func NewJanitor(db database.TaskDB, enabled bool, retentionPeriod int64, pause int64) Janitor {
+	return Janitor{
+		db:              db,
+		enabled:         enabled,
+		retentionPeriod: retentionPeriod,
+		pause:           pause,
+	}
+}
+
+func (j Janitor) Run() {
+	if j.enabled {
+		j.runLoop()
+	} else {
+		j.runWaitForEvent()
+	}
+}
+
+func (j Janitor) runWaitForEvent() {
+	select {}
+}
+
+func (j Janitor) runLoop() {
+	j.purgeTerminatedTasks()
+	time.Sleep(time.Duration(j.pause) * time.Second)
+}
+
+func (j Janitor) purgeTerminatedTasks() error {
+	tasks, err := j.db.ListTerminatedTasks()
+	if err != nil {
+		return err
+	}
+	for _, t := range tasks {
+		if t.IsExpired(j.retentionPeriod) {
+			err = j.db.RemoveTask(t.ID)
+			if err != nil {
+				logrus.WithError(err).Error("Purge of tasks failed. Stopping purge process.")
+				break
+			}
+		}
+	}
+	return err
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -51,6 +51,12 @@ func Create(scheduler types.Scheduler, conf *config.Config) *mux.Router {
 			Handler: h.ListRunningTasks(),
 		},
 		types.Route{
+			Name:    "ListFinishedTasks",
+			Method:  "GET",
+			Pattern: "/history",
+			Handler: h.ListTerminatedTasks(),
+		},
+		types.Route{
 			Name:    "Index",
 			Method:  "GET",
 			Pattern: "/",

--- a/routes/routes_test.go
+++ b/routes/routes_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRoutes(t *testing.T) {
-	routes := []string{"AddTask", "Status", "ListRunningTasks"}
+	routes := []string{"AddTask", "Status", "ListRunningTasks", "ListFinishedTasks"}
 
 	dir, _ := os.Getwd()
 	db, err := database.NewDB("boltdb", fmt.Sprintf("%s/../db/test.db", dir))

--- a/types/task.go
+++ b/types/task.go
@@ -159,3 +159,14 @@ func (task *EremeticTask) LastUpdated() time.Time {
 func (task *EremeticTask) UpdateStatus(status Status) {
 	task.Status = append(task.Status, status)
 }
+
+func (task *EremeticTask) IsExpired(retentionPeriod int64) bool {
+	if task.IsTerminated() {
+		st := task.Status[len(task.Status)-1]
+		delta := time.Now().Unix() - st.Time
+		if delta > retentionPeriod {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- add /history endpoint
- add a janitor package to remove old task from primary db

I shared the very early version of my work on task management for incremental review. 
First step is to expose terminated task (aka history) and remove them from primary db (and maybe move them into a long term storage one day) based on an user defined retention period. Unit testing are missing by now and this version will run in my test environment during my vacation. It's also a technique to familiarize myself with tasks lifecycle in eremetic.
When it's OK, I'd like to add cancelation of queued requests (via DELETE HTTP verb), purge via HTTP endpoint and resuming queue on startup (it'd be designed to be fail over compliant).
Please don't merge :)
