### PR TITLE
Remove the response body on adding a task

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -71,7 +71,7 @@ func (h Handler) AddTask() http.HandlerFunc {
 		}
 
 		w.Header().Set("Location", absURL(r, fmt.Sprintf("/task/%s", taskID)))
-		writeJSON(http.StatusAccepted, taskID, w)
+		w.WriteHeader(http.StatusAccepted)
 	}
 }
 


### PR DESCRIPTION
The semantic way is to provide the new resource in the Location header. Returning a response body is redundant.
