### PR TITLE
Add /api/v1/ routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ server/assets/assets.go
 ._*
 *\.sw[op]
 vendor/*
+*.orig

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ PACKAGES=$(shell go list ./... | grep -v /vendor/)
 
 all: test
 
+glide:
+	curl https://glide.sh/get | sh
+
 deps:
 	glide install
 
@@ -36,7 +39,7 @@ test-server: ${TOOLS}
 
 # Run tests cleanly in a docker container.
 test-docker:
-	$(DOCKER_GOLANG_RUN_CMD) "make test"
+	$(DOCKER_GOLANG_RUN_CMD) "make glide test"
 
 vet:
 	go vet ${PACKAGES}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Send a cURL to the eremetic framework with how much cpu and memory you need, wha
 ```bash
 curl -H "Content-Type: application/json" \
      -X POST \
-     -d '{"task_mem":22.0, "task_cpus":1.0, "docker_image": "a_docker_container", "command": "rails"}' \
-     http://eremetic_server:8080/task
+     -d '{"mem":22.0, "cpu":1.0, "image": "busybox", "command": "echo $(date)"}' \
+     http://eremetic_server:8080/api/v1/task
 ```
 
 These basic fields are required but you can also specify volumes, ports, environment
@@ -29,15 +29,15 @@ JSON format:
 ```javascript
 {
   // Float64, fractions of a CPU to request
-  "task_cpus":      1.0,
+  "cpu":      1.0,
   // Float64, memory to use (MiB)
-  "task_mem":       22.0,
+  "mem":       22.0,
   // String, full tag or hash of container to run
-  "docker_image":   "busybox",
+  "image":   "busybox",
   // Boolean, if set to true, docker image will be pulled before each task launch.
   "force_pull_image": false,
   // String, command to run in the docker container
-  "command": "echo date",
+  "command": "echo $(date)",
   // Array of Strings, arguements to pass to the docker container entrypoint
   "args": ["+%s"],
   // Array of Objects, volumes to mount in the container
@@ -68,13 +68,8 @@ JSON format:
   "masked_env": {
     "KEY": "value"
   },
-  // URIs of resource to download
-  "uris": [
-    "http://server.local/resource"
-  ],
-  // URIs and attributes of resource to download
-  // Please note that `uris` auto-extract archive files based on their extension
-  // with `fetch`, you need to explicitly define `"extract"` to unarchive files.
+  // URIs and attributes of resource to download. You need to explicitly define 
+  // `"extract"` to unarchive files.
   "fetch": [
     {
       "uri" : "http://server.local/another_resource",
@@ -83,10 +78,10 @@ JSON format:
       "cache": false
     }
   ],
-  // Constraints for which slave the task can run on (beyond cpu/memory).
+  // Constraints for which agent the task can run on (beyond cpu/memory).
   // Matching is strict and only attributes are currently supported. If
   // multiple constraints exist, they are evaluated using AND (ie: all or none).
-  "slave_constraints": [
+  "agent_constraints": [
       {
           "attribute_name": "aws-region",
           "attribute_value": "us-west-2"
@@ -103,7 +98,7 @@ Most of this meta-data will not remain after a full restart of Eremetic.
 
 ### Clarification of the Masked Env field
 The purpose of the field is to provide a way to pass along environment variables that you don't want to have exposed in a subsequent GET call.
-It is not intended to provide full security, as someone with access to either the machine running Eremetic or the Mesos Slave that the task is being run on will still be able to view these values.
+It is not intended to provide full security, as someone with access to either the machine running Eremetic or the Mesos Agent that the task is being run on will still be able to view these values.
 These values are not encrypted, but simply masked when retrieved back via the API.
 
 For security purposes, ensure TLS (https) is being used for the Eremetic communication and that access to any machines is properly restricted.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/eremetic-framework/eremetic"
+)
+
+var task = eremetic.Task{
+	TaskCPUs:          12,
+	TaskMem:           255,
+	Command:           "task.Command",
+	Args:              []string{"task.Args"},
+	User:              "task.User",
+	Environment:       map[string]string{"key": "value"},
+	MaskedEnvironment: map[string]string{"key2": "masked_value"},
+	Image:             "task.Image",
+	Volumes:           []eremetic.Volume{},
+	Ports:             []eremetic.Port{},
+	Status:            []eremetic.Status{eremetic.Status{Status: eremetic.TaskFinished, Time: 0}},
+	ID:                "task.ID",
+	Name:              "task.Name",
+	Network:           "task.Network",
+	DNS:               "task.DNS",
+	FrameworkID:       "task.FrameworkID",
+	AgentID:           "task.AgentID",
+	AgentConstraints:  []eremetic.AgentConstraint{},
+	Hostname:          "task.Hostname",
+	Retry:             5,
+	CallbackURI:       "task.CallbackURI",
+	SandboxPath:       "task.SandboxPath",
+	AgentIP:           "task.AgentIP",
+	AgentPort:         1234,
+	ForcePullImage:    true,
+	FetchURIs:         []eremetic.URI{},
+}
+
+func TestAPI_V0_TaskV0FromTask_TaskFromV0(t *testing.T) {
+	t0 := TaskV0FromTask(&task)
+	ta := TaskFromV0(&t0)
+	if !reflect.DeepEqual(ta, task) {
+		t.Fatalf("Invalid conversion.\nExpected:\t%+v\nActual:\t%+v", ta, task)
+	}
+}
+
+func TestAPI_V1_TaskV1FromTask_TaskFromV1(t *testing.T) {
+	t1 := TaskV1FromTask(&task)
+	ta := TaskFromV1(&t1)
+	if !reflect.DeepEqual(ta, task) {
+		t.Fatalf("Invalid conversion.\nExpected:\t%+v\nActual:\t%+v", ta, task)
+	}
+}

--- a/api/api_v0.go
+++ b/api/api_v0.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"github.com/eremetic-framework/eremetic"
+)
+
+// TaskV0 defines the deprecated json-structure for the properties of a scheduled task.
+type TaskV0 struct {
+	TaskCPUs          float64                    `json:"task_cpus"`
+	TaskMem           float64                    `json:"task_mem"`
+	Command           string                     `json:"command"`
+	Args              []string                   `json:"args"`
+	User              string                     `json:"user"`
+	Environment       map[string]string          `json:"env"`
+	MaskedEnvironment map[string]string          `json:"masked_env"`
+	Image             string                     `json:"image"`
+	Volumes           []eremetic.Volume          `json:"volumes"`
+	Ports             []eremetic.Port            `json:"ports"`
+	Status            []eremetic.Status          `json:"status"`
+	ID                string                     `json:"id"`
+	Name              string                     `json:"name"`
+	Network           string                     `json:"network"`
+	DNS               string                     `json:"dns"`
+	FrameworkID       string                     `json:"framework_id"`
+	AgentID           string                     `json:"slave_id"`
+	AgentConstraints  []eremetic.AgentConstraint `json:"slave_constraints"`
+	Hostname          string                     `json:"hostname"`
+	Retry             int                        `json:"retry"`
+	CallbackURI       string                     `json:"callback_uri"`
+	SandboxPath       string                     `json:"sandbox_path"`
+	AgentIP           string                     `json:"agent_ip"`
+	AgentPort         int32                      `json:"agent_port"`
+	ForcePullImage    bool                       `json:"force_pull_image"`
+	FetchURIs         []eremetic.URI             `json:"fetch"`
+}
+
+// TaskV0FromTask is needed for Go versions < 1.8
+// In go 1.8, TaskV0(Task) would work instead
+func TaskV0FromTask(task *eremetic.Task) TaskV0 {
+	return TaskV0{
+		TaskCPUs:          task.TaskCPUs,
+		TaskMem:           task.TaskMem,
+		Command:           task.Command,
+		Args:              task.Args,
+		User:              task.User,
+		Environment:       task.Environment,
+		MaskedEnvironment: task.MaskedEnvironment,
+		Image:             task.Image,
+		Volumes:           task.Volumes,
+		Ports:             task.Ports,
+		Status:            task.Status,
+		ID:                task.ID,
+		Name:              task.Name,
+		Network:           task.Network,
+		DNS:               task.DNS,
+		FrameworkID:       task.FrameworkID,
+		AgentID:           task.AgentID,
+		AgentConstraints:  task.AgentConstraints,
+		Hostname:          task.Hostname,
+		Retry:             task.Retry,
+		CallbackURI:       task.CallbackURI,
+		SandboxPath:       task.SandboxPath,
+		AgentIP:           task.AgentIP,
+		AgentPort:         task.AgentPort,
+		ForcePullImage:    task.ForcePullImage,
+		FetchURIs:         task.FetchURIs,
+	}
+}
+
+// TaskFromV0 is needed for Go versions < 1.8
+// In go 1.8, Task(TaskV0) would work instead
+func TaskFromV0(task *TaskV0) eremetic.Task {
+	return eremetic.Task{
+		TaskCPUs:          task.TaskCPUs,
+		TaskMem:           task.TaskMem,
+		Command:           task.Command,
+		Args:              task.Args,
+		User:              task.User,
+		Environment:       task.Environment,
+		MaskedEnvironment: task.MaskedEnvironment,
+		Image:             task.Image,
+		Volumes:           task.Volumes,
+		Ports:             task.Ports,
+		Status:            task.Status,
+		ID:                task.ID,
+		Name:              task.Name,
+		Network:           task.Network,
+		DNS:               task.DNS,
+		FrameworkID:       task.FrameworkID,
+		AgentID:           task.AgentID,
+		AgentConstraints:  task.AgentConstraints,
+		Hostname:          task.Hostname,
+		Retry:             task.Retry,
+		CallbackURI:       task.CallbackURI,
+		SandboxPath:       task.SandboxPath,
+		AgentIP:           task.AgentIP,
+		AgentPort:         task.AgentPort,
+		ForcePullImage:    task.ForcePullImage,
+		FetchURIs:         task.FetchURIs,
+	}
+}
+
+// RequestV0 represents the old deprecated json-structure of a job request
+type RequestV0 struct {
+	TaskCPUs          float64                    `json:"task_cpus"`
+	TaskMem           float64                    `json:"task_mem"`
+	DockerImage       string                     `json:"docker_image"`
+	Command           string                     `json:"command"`
+	Args              []string                   `json:"args"`
+	Volumes           []eremetic.Volume          `json:"volumes"`
+	Ports             []eremetic.Port            `json:"ports"`
+	Network           string                     `json:"network"`
+	DNS               string                     `json:"dns"`
+	Environment       map[string]string          `json:"env"`
+	MaskedEnvironment map[string]string          `json:"masked_env"`
+	AgentConstraints  []eremetic.AgentConstraint `json:"slave_constraints"`
+	CallbackURI       string                     `json:"callback_uri"`
+	URIs              []string                   `json:"uris"`
+	Fetch             []eremetic.URI             `json:"fetch"`
+	ForcePullImage    bool                       `json:"force_pull_image"`
+}
+
+// RequestFromV0 is needed for Go versions < 1.8
+// In go 1.8, Request(RequestV0) would work instead
+func RequestFromV0(req RequestV0) eremetic.Request {
+	return eremetic.Request{
+		TaskCPUs:          req.TaskCPUs,
+		TaskMem:           req.TaskMem,
+		DockerImage:       req.DockerImage,
+		Command:           req.Command,
+		Args:              req.Args,
+		Volumes:           req.Volumes,
+		Ports:             req.Ports,
+		Network:           req.Network,
+		DNS:               req.DNS,
+		Environment:       req.Environment,
+		MaskedEnvironment: req.MaskedEnvironment,
+		AgentConstraints:  req.AgentConstraints,
+		CallbackURI:       req.CallbackURI,
+		URIs:              req.URIs,
+		Fetch:             req.Fetch,
+		ForcePullImage:    req.ForcePullImage,
+	}
+}

--- a/api/api_v1.go
+++ b/api/api_v1.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"github.com/eremetic-framework/eremetic"
+)
+
+// TaskV1 defines the API V1 json-structure for the properties of a scheduled task.
+type TaskV1 struct {
+	TaskCPUs          float64                    `json:"cpu"`
+	TaskMem           float64                    `json:"mem"`
+	Command           string                     `json:"command"`
+	Args              []string                   `json:"args"`
+	User              string                     `json:"user"`
+	Environment       map[string]string          `json:"env"`
+	MaskedEnvironment map[string]string          `json:"masked_env"`
+	Image             string                     `json:"image"`
+	Volumes           []eremetic.Volume          `json:"volumes"`
+	Ports             []eremetic.Port            `json:"ports"`
+	Status            []eremetic.Status          `json:"status"`
+	ID                string                     `json:"id"`
+	Name              string                     `json:"name"`
+	Network           string                     `json:"network"`
+	DNS               string                     `json:"dns"`
+	FrameworkID       string                     `json:"framework_id"`
+	AgentID           string                     `json:"agent_id"`
+	AgentConstraints  []eremetic.AgentConstraint `json:"agent_constraints"`
+	Hostname          string                     `json:"hostname"`
+	Retry             int                        `json:"retry"`
+	CallbackURI       string                     `json:"callback_uri"`
+	SandboxPath       string                     `json:"sandbox_path"`
+	AgentIP           string                     `json:"agent_ip"`
+	AgentPort         int32                      `json:"agent_port"`
+	ForcePullImage    bool                       `json:"force_pull_image"`
+	FetchURIs         []eremetic.URI             `json:"fetch"`
+}
+
+// TaskV1FromTask is needed for Go versions < 1.8
+// In go 1.8, TaskV1(Task) would work instead
+func TaskV1FromTask(task *eremetic.Task) TaskV1 {
+	return TaskV1{
+		TaskCPUs:          task.TaskCPUs,
+		TaskMem:           task.TaskMem,
+		Command:           task.Command,
+		Args:              task.Args,
+		User:              task.User,
+		Environment:       task.Environment,
+		MaskedEnvironment: task.MaskedEnvironment,
+		Image:             task.Image,
+		Volumes:           task.Volumes,
+		Ports:             task.Ports,
+		Status:            task.Status,
+		ID:                task.ID,
+		Name:              task.Name,
+		Network:           task.Network,
+		DNS:               task.DNS,
+		FrameworkID:       task.FrameworkID,
+		AgentID:           task.AgentID,
+		AgentConstraints:  task.AgentConstraints,
+		Hostname:          task.Hostname,
+		Retry:             task.Retry,
+		CallbackURI:       task.CallbackURI,
+		SandboxPath:       task.SandboxPath,
+		AgentIP:           task.AgentIP,
+		AgentPort:         task.AgentPort,
+		ForcePullImage:    task.ForcePullImage,
+		FetchURIs:         task.FetchURIs,
+	}
+}
+
+// TaskFromV1 is needed for Go versions < 1.8
+// In go 1.8, Task(TaskV1) would work instead
+func TaskFromV1(task *TaskV1) eremetic.Task {
+	return eremetic.Task{
+		TaskCPUs:          task.TaskCPUs,
+		TaskMem:           task.TaskMem,
+		Command:           task.Command,
+		Args:              task.Args,
+		User:              task.User,
+		Environment:       task.Environment,
+		MaskedEnvironment: task.MaskedEnvironment,
+		Image:             task.Image,
+		Volumes:           task.Volumes,
+		Ports:             task.Ports,
+		Status:            task.Status,
+		ID:                task.ID,
+		Name:              task.Name,
+		Network:           task.Network,
+		DNS:               task.DNS,
+		FrameworkID:       task.FrameworkID,
+		AgentID:           task.AgentID,
+		AgentConstraints:  task.AgentConstraints,
+		Hostname:          task.Hostname,
+		Retry:             task.Retry,
+		CallbackURI:       task.CallbackURI,
+		SandboxPath:       task.SandboxPath,
+		AgentIP:           task.AgentIP,
+		AgentPort:         task.AgentPort,
+		ForcePullImage:    task.ForcePullImage,
+		FetchURIs:         task.FetchURIs,
+	}
+}
+
+// RequestV1 represents the V1 json-structure of a job request
+type RequestV1 struct {
+	TaskCPUs          float64                    `json:"cpu"`
+	TaskMem           float64                    `json:"mem"`
+	DockerImage       string                     `json:"image"`
+	Command           string                     `json:"command"`
+	Args              []string                   `json:"args"`
+	Volumes           []eremetic.Volume          `json:"volumes"`
+	Ports             []eremetic.Port            `json:"ports"`
+	Network           string                     `json:"network"`
+	DNS               string                     `json:"dns"`
+	Environment       map[string]string          `json:"env"`
+	MaskedEnvironment map[string]string          `json:"masked_env"`
+	AgentConstraints  []eremetic.AgentConstraint `json:"agent_constraints"`
+	CallbackURI       string                     `json:"callback_uri"`
+	Fetch             []eremetic.URI             `json:"fetch"`
+	ForcePullImage    bool                       `json:"force_pull_image"`
+}
+
+// RequestFromV1 is needed for Go versions < 1.8
+// In go 1.8, Request(RequestV1) would work instead
+func RequestFromV1(req RequestV1) eremetic.Request {
+	return eremetic.Request{
+		TaskCPUs:          req.TaskCPUs,
+		TaskMem:           req.TaskMem,
+		DockerImage:       req.DockerImage,
+		Command:           req.Command,
+		Args:              req.Args,
+		Volumes:           req.Volumes,
+		Ports:             req.Ports,
+		Network:           req.Network,
+		DNS:               req.DNS,
+		Environment:       req.Environment,
+		MaskedEnvironment: req.MaskedEnvironment,
+		AgentConstraints:  req.AgentConstraints,
+		CallbackURI:       req.CallbackURI,
+		URIs:              []string{},
+		Fetch:             req.Fetch,
+		ForcePullImage:    req.ForcePullImage,
+	}
+}

--- a/api/route.go
+++ b/api/route.go
@@ -1,0 +1,14 @@
+package api
+
+import "net/http"
+
+// Route enforces the structure of a route
+type Route struct {
+	Name    string
+	Method  string
+	Pattern string
+	Handler http.Handler
+}
+
+// Routes is a collection of route structs
+type Routes []Route

--- a/api/version.go
+++ b/api/version.go
@@ -1,0 +1,7 @@
+package api
+
+// API Version constants
+const (
+	V0 = "apiv0"
+	V1 = "apiv1"
+)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/eremetic-framework/eremetic"
+	"github.com/eremetic-framework/eremetic/api"
+	"github.com/eremetic-framework/eremetic/version"
 )
 
 func TestClient_AddTask(t *testing.T) {
@@ -21,7 +23,7 @@ func TestClient_AddTask(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var req eremetic.Request
+	var req api.RequestV1
 
 	if err := c.AddTask(req); err != nil {
 		t.Fatal(err)
@@ -68,5 +70,67 @@ func TestClient_KillTask(t *testing.T) {
 
 	if err := c.Kill("1234"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestClient_ReadTask(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"mem":22.0, "image": "busybox", "command": "echo hello", "cpu":0.5}`))
+	}))
+	defer ts.Close()
+
+	var httpClient http.Client
+	c, err := New(ts.URL, &httpClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := c.Task("1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if task.TaskMem != 22 || task.Image != "busybox" || task.Command != "echo hello" || task.TaskCPUs != 0.5 {
+		t.Fatal(errors.New("Unexpected task"))
+	}
+}
+func TestClient_Version(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(version.Version))
+	}))
+	defer ts.Close()
+
+	var httpClient http.Client
+	c, err := New(ts.URL, &httpClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	version, err := c.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(version) == 0 {
+		t.Fatal("Missing version")
+	}
+}
+
+func TestClient_Sandbox(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("remember remember the 5th of november\nthe gunpowder treason and plot.\nI see no reason the gunpowder treason should ever be forgot.\n"))
+	}))
+	defer ts.Close()
+
+	var httpClient http.Client
+	c, err := New(ts.URL, &httpClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poem, err := c.Sandbox("1234", "poem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(poem) == 0 {
+		t.Fatal("Failed to get file")
 	}
 }

--- a/database.go
+++ b/database.go
@@ -76,7 +76,7 @@ func (db *DefaultTaskDB) ReadTask(id string) (Task, error) {
 	return Task{}, errors.New("unknown task")
 }
 
-// Deletes the task with a given id, or an error if not found.
+// DeleteTask removes the task with a given id, or an error if not found.
 func (db *DefaultTaskDB) DeleteTask(id string) error {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()
@@ -86,7 +86,6 @@ func (db *DefaultTaskDB) DeleteTask(id string) error {
 	}
 	return errors.New("unknown task")
 }
-
 
 // ReadUnmaskedTask returns a task with all its environment variables unmasked.
 func (db *DefaultTaskDB) ReadUnmaskedTask(id string) (Task, error) {

--- a/misc/swagger.yaml
+++ b/misc/swagger.yaml
@@ -9,7 +9,7 @@ basePath: /
 produces:
   - application/json
 paths:
-  /task:
+  /api/v1/task:
     get:
       summary: List running tasks
       description: |
@@ -41,7 +41,7 @@ paths:
             type: string
         default:
           description: Unexpected error
-  /task/{taskId}:
+  /api/v1/task/{taskId}:
     get:
       summary: Get status of task
       description: |
@@ -71,6 +71,21 @@ definitions:
       host_path:
         type: string
         description: Path on host to mount
+  URI:
+    type: object
+    properties:
+      uri:
+        type: string
+        description: URI to fetch
+      extract:
+        type: boolean
+        description: True if the file should be extracted after being fetched
+      executable:
+        type: boolean
+        description: True if the file should be flagged as executable
+      cache:
+        type: boolean
+        description: True if the file should be cached
   Tasks:
     type: array
     items:
@@ -78,10 +93,10 @@ definitions:
   Task:
     type: object
     required:
-      - docker_image
+      - image
       - command
-      - task_cpu
-      - task_mem
+      - cpu
+      - mem
     properties:
       id:
         type: string
@@ -91,7 +106,7 @@ definitions:
         type: string
         readOnly: true
         description: Name of task
-      docker_image:
+      image:
         type: string
         description: Full tag or hash of container to run
       command:
@@ -104,29 +119,30 @@ definitions:
         type: string
         description: DNS to be used by the container
       args:
-        type: array 
+        type: array
+        items:
+          type: string
         description: arguements to pass to the docker container entrypoint
-      task_cpu:
+      cpu:
         type: number
         description: Fractions of a CPU to request
-      task_mem:
+      mem:
         type: number
         description: memory to use (MiB)
       volumes:
         type: array
         items:
           $ref: '#/definitions/Volume'
+      fetch:
+        type: array
+        items:
+          $ref: '#/definitions/URI'
       env:
         type: object
         description: Environment variables to set
       masked_env:
         type: object
         description: Environment variables to set but that are masked in any GET request.
-      uris:
-        type: array
-        items:
-          type: string
-          description: URI of resource to download
       callback_uri:
         type: string
         description: URL to post a callback to
@@ -134,7 +150,7 @@ definitions:
         type: string
         readOnly: true
         description: Framework ID used when launching task
-      slave_id:
+      agent_id:
         type: string
         readOnly: true
         description: Id of slave where task is running

--- a/server/handler_v1_test.go
+++ b/server/handler_v1_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/eremetic-framework/eremetic/version"
 )
 
-func TestHandling(t *testing.T) {
+func TestHandlingV1(t *testing.T) {
 	scheduler := &mock.ErrScheduler{}
 	status := []eremetic.Status{
 		eremetic.Status{
@@ -58,15 +58,15 @@ func TestHandling(t *testing.T) {
 
 		wr := httptest.NewRecorder()
 		m := mux.NewRouter()
-		r, _ := http.NewRequest("GET", fmt.Sprintf("/task/%s", id), nil)
+		r, _ := http.NewRequest("GET", fmt.Sprintf("/api/v1/task/%s", id), nil)
 
 		Convey("GetTaskInfo", func() {
-			m.HandleFunc("/task/{taskId}", h.GetTaskInfo(&config.Config{}, api.V0))
+			m.HandleFunc("/api/v1/task/{taskId}", h.GetTaskInfo(&config.Config{}, api.V1))
 
 			Convey("JSON request", func() {
 				Convey("Not Found", func() {
 					id = "eremetic-task.5678"
-					r.URL, _ = url.Parse(fmt.Sprintf("/task/%s", id))
+					r.URL, _ = url.Parse(fmt.Sprintf("/api/v1/task/%s", id))
 
 					db.PutTask(&task)
 					m.ServeHTTP(wr, r)
@@ -85,7 +85,7 @@ func TestHandling(t *testing.T) {
 					db.PutTask(&task)
 					m.ServeHTTP(wr, r)
 
-					var retrievedTask api.TaskV0
+					var retrievedTask api.TaskV1
 					body, _ := ioutil.ReadAll(io.LimitReader(wr.Body, 1048576))
 					json.Unmarshal(body, &retrievedTask)
 
@@ -95,61 +95,30 @@ func TestHandling(t *testing.T) {
 
 				})
 			})
-
-			Convey("text/html request", func() {
-				r.Header.Add("Accept", "text/html")
-
-				Convey("Not Found", func() {
-					id = "eremetic-task.5678"
-					r.URL, _ = url.Parse(fmt.Sprintf("/task/%s", id))
-
-					db.PutTask(&task)
-					m.ServeHTTP(wr, r)
-
-					b, _ := ioutil.ReadAll(wr.Body)
-					body := string(b)
-
-					So(wr.Code, ShouldEqual, http.StatusNotFound)
-					So(body, ShouldContainSubstring, "<title>404 Not Found | Eremetic</title>")
-				})
-
-				Convey("Found", func() {
-					db.PutTask(&task)
-					m.ServeHTTP(wr, r)
-
-					b, _ := ioutil.ReadAll(wr.Body)
-					body := string(b)
-					So(wr.Code, ShouldEqual, http.StatusOK)
-					lookup := fmt.Sprintf("<body data-task=\"%s\">", id)
-					So(body, ShouldContainSubstring, lookup)
-					status := "<div class=\"ui task_running label\">"
-					So(body, ShouldContainSubstring, status)
-				})
-			})
 		})
 
 		Convey("AddTask", func() {
-			data := []byte(`{"task_mem":22.0, "docker_image": "busybox", "command": "echo hello", "task_cpus":0.5, "tasks_to_launch": 1}`)
-			r, _ := http.NewRequest("POST", "/task", bytes.NewBuffer(data))
+			data := []byte(`{"mem":22.0, "image": "busybox", "command": "echo hello", "cpu":0.5}`)
+			r, _ := http.NewRequest("POST", "/api/v1/task", bytes.NewBuffer(data))
 			r.Host = "localhost"
 
 			Convey("It should respond with a location header", func() {
-				handler := h.AddTask(&config.Config{}, api.V0)
+				handler := h.AddTask(&config.Config{}, api.V1)
 				handler(wr, r)
 
 				location := wr.HeaderMap["Location"][0]
-				So(location, ShouldStartWith, "http://localhost/task/eremetic-task.")
+				So(location, ShouldStartWith, "http://localhost/api/v1/task/eremetic-task.")
 				So(wr.Code, ShouldEqual, http.StatusAccepted)
 			})
 
 			Convey("It should respond with a location per URL prefix header", func() {
 				conf := config.Config{}
 				conf.URLPrefix = "/service/eremetic"
-				handler := h.AddTask(&conf, api.V0)
+				handler := h.AddTask(&conf, api.V1)
 				handler(wr, r)
 
 				location := wr.HeaderMap["Location"][0]
-				So(location, ShouldStartWith, "http://localhost/service/eremetic/task/eremetic-task.")
+				So(location, ShouldStartWith, "http://localhost/service/eremetic/api/v1/task/eremetic-task.")
 				So(wr.Code, ShouldEqual, http.StatusAccepted)
 			})
 
@@ -157,7 +126,7 @@ func TestHandling(t *testing.T) {
 				err := errors.New("A random error")
 				scheduler.NextError = &err
 
-				handler := h.AddTask(&config.Config{}, api.V0)
+				handler := h.AddTask(&config.Config{}, api.V1)
 				handler(wr, r)
 
 				So(wr.Code, ShouldEqual, 500)
@@ -166,7 +135,7 @@ func TestHandling(t *testing.T) {
 			Convey("Error on bad input stream", func() {
 				r.Body = ioutil.NopCloser(&mock.ErrorReader{})
 
-				handler := h.AddTask(&config.Config{}, api.V0)
+				handler := h.AddTask(&config.Config{}, api.V1)
 				handler(wr, r)
 
 				So(wr.Code, ShouldEqual, 422)
@@ -176,7 +145,7 @@ func TestHandling(t *testing.T) {
 				data = []byte(`{"key:123}`)
 				r.Body = ioutil.NopCloser(bytes.NewBuffer(data))
 
-				handler := h.AddTask(&config.Config{}, api.V0)
+				handler := h.AddTask(&config.Config{}, api.V1)
 				handler(wr, r)
 
 				So(wr.Code, ShouldEqual, 422)
@@ -209,8 +178,8 @@ func TestHandling(t *testing.T) {
 				db.PutTask(&task)
 
 				Convey("stdout", func() {
-					r, _ := http.NewRequest("GET", "/task/eremetic-task.1234/stdout", nil)
-					m.HandleFunc("/task/{taskId}/stdout", h.GetFromSandbox("stdout", api.V0))
+					r, _ := http.NewRequest("GET", "/api/v1/task/eremetic-task.1234/stdout", nil)
+					m.HandleFunc("/api/v1/task/{taskId}/stdout", h.GetFromSandbox("stdout", api.V1))
 					m.ServeHTTP(wr, r)
 
 					So(wr.Code, ShouldEqual, http.StatusOK)
@@ -221,8 +190,8 @@ func TestHandling(t *testing.T) {
 				})
 
 				Convey("stderr", func() {
-					r, _ := http.NewRequest("GET", "/task/eremetic-task.1234/stderr", nil)
-					m.HandleFunc("/task/{taskId}/stderr", h.GetFromSandbox("stderr", api.V0))
+					r, _ := http.NewRequest("GET", "/api/v1/task/eremetic-task.1234/stderr", nil)
+					m.HandleFunc("/api/v1/task/{taskId}/stderr", h.GetFromSandbox("stderr", api.V1))
 
 					m.ServeHTTP(wr, r)
 
@@ -234,8 +203,8 @@ func TestHandling(t *testing.T) {
 				})
 
 				Convey("No Sandbox path", func() {
-					r, _ := http.NewRequest("GET", "/task/eremetic-task.1234/stdout", nil)
-					m.HandleFunc("/task/{taskId}/stdout", h.GetFromSandbox("stdout", api.V0))
+					r, _ := http.NewRequest("GET", "/api/v1/task/eremetic-task.1234/stdout", nil)
+					m.HandleFunc("/api/v1/task/{taskId}/stdout", h.GetFromSandbox("stdout", api.V1))
 
 					task := eremetic.Task{
 						TaskCPUs:    0.2,
@@ -261,7 +230,7 @@ func TestHandling(t *testing.T) {
 		Convey("Version", func() {
 			version.Version = "test"
 			r, _ := http.NewRequest("GET", "/version", nil)
-			m.HandleFunc("/version", h.Version(&config.Config{}, api.V0))
+			m.HandleFunc("/version", h.Version(&config.Config{}, api.V1))
 			m.ServeHTTP(wr, r)
 
 			body, _ := ioutil.ReadAll(wr.Body)
@@ -269,8 +238,8 @@ func TestHandling(t *testing.T) {
 		})
 
 		Convey("Delete task", func() {
-			r, _ := http.NewRequest("DELETE", fmt.Sprintf("/task/%s", id), nil)
-			m.HandleFunc("/task/{taskId}", h.DeleteTask(&config.Config{}, api.V0)).Methods("DELETE")
+			r, _ := http.NewRequest("DELETE", fmt.Sprintf("/api/v1/task/%s", id), nil)
+			m.HandleFunc("/api/v1/task/{taskId}", h.DeleteTask(&config.Config{}, api.V1)).Methods("DELETE")
 
 			Convey("Task deleted successfully", func() {
 				statusQueued := []eremetic.Status{
@@ -289,9 +258,9 @@ func TestHandling(t *testing.T) {
 					MaskedEnvironment: maskedEnv,
 				}
 				db.PutTask(&task)
-				r.URL, _ = url.Parse(fmt.Sprintf("/task/%s", id))
+				r.URL, _ = url.Parse(fmt.Sprintf("/api/v1/task/%s", id))
 
-				m.HandleFunc("/task/{task}", h.DeleteTask(&config.Config{}, api.V0))
+				m.HandleFunc("/api/v1/task/{task}", h.DeleteTask(&config.Config{}, api.V1))
 				m.ServeHTTP(wr, r)
 
 				So(wr.Code, ShouldEqual, http.StatusAccepted)
@@ -300,9 +269,9 @@ func TestHandling(t *testing.T) {
 
 			Convey("Task is in running state", func() {
 				db.PutTask(&task)
-				r.URL, _ = url.Parse(fmt.Sprintf("/task/%s", id))
+				r.URL, _ = url.Parse(fmt.Sprintf("/api/v1/task/%s", id))
 
-				m.HandleFunc("/task/{task}", h.DeleteTask(&config.Config{}, api.V0))
+				m.HandleFunc("/api/v1/task/{task}", h.DeleteTask(&config.Config{}, api.V1))
 				m.ServeHTTP(wr, r)
 
 				So(wr.Code, ShouldEqual, http.StatusConflict)
@@ -310,59 +279,14 @@ func TestHandling(t *testing.T) {
 
 			Convey("Task not found", func() {
 				id = "eremetic-task.4567"
-				r.URL, _ = url.Parse(fmt.Sprintf("/task/%s", id))
+				r.URL, _ = url.Parse(fmt.Sprintf("/api/v1/task/%s", id))
 
-				m.HandleFunc("/task/{task}", h.DeleteTask(&config.Config{}, api.V0))
+				m.HandleFunc("/api/v1/task/{task}", h.DeleteTask(&config.Config{}, api.V1))
 				m.ServeHTTP(wr, r)
 
 				So(wr.Code, ShouldEqual, http.StatusNotFound)
 			})
 
 		})
-
-		Convey("Index", func() {
-			r, _ := http.NewRequest("GET", "/", nil)
-
-			Convey("Renders nothing for json", func() {
-				m.HandleFunc("/", h.IndexHandler(&config.Config{}))
-				m.ServeHTTP(wr, r)
-
-				So(wr.Code, ShouldEqual, http.StatusNoContent)
-			})
-
-			Convey("Renders the html template for html requests when URLPrefix is empty", func() {
-				conf := config.DefaultConfig()
-
-				r.Header.Add("Accept", "text/html")
-				m.HandleFunc("/", h.IndexHandler(conf))
-				m.ServeHTTP(wr, r)
-
-				b, _ := ioutil.ReadAll(wr.Body)
-				body := string(b)
-
-				So(wr.Code, ShouldEqual, http.StatusOK)
-				So(body, ShouldContainSubstring, "<html>")
-				So(body, ShouldContainSubstring, "<div id='eremetic-version'>test</div>")
-				So(body, ShouldNotContainSubstring, "/service/eremetic")
-			})
-
-			Convey("Renders the html template for html requests when URLPrefix is set", func() {
-				conf := config.DefaultConfig()
-				conf.URLPrefix = "/service/eremetic"
-
-				r.Header.Add("Accept", "text/html")
-				m.HandleFunc("/", h.IndexHandler(conf))
-				m.ServeHTTP(wr, r)
-
-				b, _ := ioutil.ReadAll(wr.Body)
-				body := string(b)
-
-				So(wr.Code, ShouldEqual, http.StatusOK)
-				So(body, ShouldContainSubstring, "<html>")
-				So(body, ShouldContainSubstring, "<div id='eremetic-version'>test</div>")
-				So(body, ShouldContainSubstring, "/service/eremetic")
-			})
-		})
-
 	})
 }

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"github.com/eremetic-framework/eremetic"
+	"github.com/eremetic-framework/eremetic/api"
 	"github.com/eremetic-framework/eremetic/config"
 	"github.com/eremetic-framework/eremetic/server/assets"
 	"github.com/eremetic-framework/eremetic/version"
@@ -231,4 +232,30 @@ func authWrap(fn http.Handler, username, password string) http.HandlerFunc {
 
 		fn.ServeHTTP(w, r)
 	}
+}
+
+func getTaskInfoV0(t eremetic.Task, conf *config.Config, id string, w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.Header.Get("Accept"), "text/html") {
+		renderHTML(w, r, t, id, conf)
+	} else {
+		task := api.TaskV0FromTask(&t)
+		if reflect.DeepEqual(task, (api.TaskV0{})) {
+			writeJSON(http.StatusNotFound, nil, w)
+			return
+		}
+		writeJSON(http.StatusOK, task, w)
+	}
+}
+
+func getTaskInfoV1(t eremetic.Task, conf *config.Config, id string, w http.ResponseWriter, r *http.Request) {
+	task := api.TaskV1FromTask(&t)
+	if reflect.DeepEqual(task, (api.TaskV1{})) {
+		writeJSON(http.StatusNotFound, nil, w)
+		return
+	}
+	writeJSON(http.StatusOK, task, w)
+}
+
+func deprecated(w http.ResponseWriter) {
+	w.Header().Set("Warning", "299 - 'Deprecated API'")
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -56,49 +56,10 @@ func NewRouter(scheduler eremetic.Scheduler, conf *config.Config, db eremetic.Ta
 }
 
 func routes(h Handler, conf *config.Config) Routes {
-	return Routes{
-		Route{
-			Name:    "AddTask",
-			Method:  "POST",
-			Pattern: "/task",
-			Handler: h.AddTask(conf),
-		},
-		Route{
-			Name:    "Status",
-			Method:  "GET",
-			Pattern: "/task/{taskId}",
-			Handler: h.GetTaskInfo(conf),
-		},
-		Route{
-			Name:    "STDOUT",
-			Method:  "GET",
-			Pattern: "/task/{taskId}/stdout",
-			Handler: h.GetFromSandbox("stdout"),
-		},
-		Route{
-			Name:    "STDERR",
-			Method:  "GET",
-			Pattern: "/task/{taskId}/stderr",
-			Handler: h.GetFromSandbox("stderr"),
-		},
-		Route{
-			Name:    "Kill",
-			Method:  "POST",
-			Pattern: "/task/{taskId}/kill",
-			Handler: h.KillTask(conf),
-		},
-		Route{
-			Name:    "Delete",
-			Method:  "DELETE",
-			Pattern: "/task/{taskId}",
-			Handler: h.DeleteTask(conf),
-		},
-		Route{
-			Name:    "ListRunningTasks",
-			Method:  "GET",
-			Pattern: "/task",
-			Handler: h.ListRunningTasks(),
-		},
+	v0routes := apiV0Routes(h, conf)
+	v1routes := apiV1Routes(h, conf)
+	apiRoutes := append(v0routes, v1routes...)
+	return append(Routes{
 		Route{
 			Name:    "Index",
 			Method:  "GET",
@@ -106,16 +67,10 @@ func routes(h Handler, conf *config.Config) Routes {
 			Handler: h.IndexHandler(conf),
 		},
 		Route{
-			Name:    "Version",
-			Method:  "GET",
-			Pattern: "/version",
-			Handler: h.Version(conf),
-		},
-		Route{
 			Name:    "Metrics",
 			Method:  "GET",
 			Pattern: "/metrics",
 			Handler: prometheus.Handler(),
 		},
-	}
+	}, apiRoutes...)
 }

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -24,7 +24,7 @@ func TestRoutes(t *testing.T) {
 	})
 
 	Convey("Expected number of routes", t, func() {
-		ExpectedNumberOfRoutes := 10 // Magic numbers FTW
+		ExpectedNumberOfRoutes := 18 // Magic numbers FTW
 
 		So(len(routes), ShouldEqual, ExpectedNumberOfRoutes)
 	})

--- a/server/routes_v0.go
+++ b/server/routes_v0.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"github.com/eremetic-framework/eremetic/api"
+	"github.com/eremetic-framework/eremetic/config"
+)
+
+func apiV0Routes(h Handler, conf *config.Config) Routes {
+	return Routes{
+		Route{
+			Name:    "AddTask",
+			Method:  "POST",
+			Pattern: "/task",
+			Handler: h.AddTask(conf, api.V0),
+		},
+		Route{
+			Name:    "Status",
+			Method:  "GET",
+			Pattern: "/task/{taskId}",
+			Handler: h.GetTaskInfo(conf, api.V0),
+		},
+		Route{
+			Name:    "STDOUT",
+			Method:  "GET",
+			Pattern: "/task/{taskId}/stdout",
+			Handler: h.GetFromSandbox("stdout", api.V0),
+		},
+		Route{
+			Name:    "STDERR",
+			Method:  "GET",
+			Pattern: "/task/{taskId}/stderr",
+			Handler: h.GetFromSandbox("stderr", api.V0),
+		},
+		Route{
+			Name:    "Kill",
+			Method:  "POST",
+			Pattern: "/task/{taskId}/kill",
+			Handler: h.KillTask(conf, api.V0),
+		},
+		Route{
+			Name:    "Delete",
+			Method:  "DELETE",
+			Pattern: "/task/{taskId}",
+			Handler: h.DeleteTask(conf, api.V0),
+		},
+		Route{
+			Name:    "ListRunningTasks",
+			Method:  "GET",
+			Pattern: "/task",
+			Handler: h.ListRunningTasks(api.V0),
+		},
+		Route{
+			Name:    "Version",
+			Method:  "GET",
+			Pattern: "/version",
+			Handler: h.Version(conf, api.V0),
+		},
+	}
+}

--- a/server/routes_v1.go
+++ b/server/routes_v1.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"github.com/eremetic-framework/eremetic/api"
+	"github.com/eremetic-framework/eremetic/config"
+)
+
+func apiV1Routes(h Handler, conf *config.Config) Routes {
+	return Routes{
+		Route{
+			Name:    "AddTask",
+			Method:  "POST",
+			Pattern: "/api/v1/task",
+			Handler: h.AddTask(conf, api.V1),
+		},
+		Route{
+			Name:    "Status",
+			Method:  "GET",
+			Pattern: "/api/v1/task/{taskId}",
+			Handler: h.GetTaskInfo(conf, api.V1),
+		},
+		Route{
+			Name:    "STDOUT",
+			Method:  "GET",
+			Pattern: "/api/v1/task/{taskId}/stdout",
+			Handler: h.GetFromSandbox("stdout", api.V1),
+		},
+		Route{
+			Name:    "STDERR",
+			Method:  "GET",
+			Pattern: "/api/v1/task/{taskId}/stderr",
+			Handler: h.GetFromSandbox("stderr", api.V1),
+		},
+		Route{
+			Name:    "Kill",
+			Method:  "POST",
+			Pattern: "/api/v1/task/{taskId}/kill",
+			Handler: h.KillTask(conf, api.V1),
+		},
+		Route{
+			Name:    "Delete",
+			Method:  "DELETE",
+			Pattern: "/api/v1/task/{taskId}",
+			Handler: h.DeleteTask(conf, api.V1),
+		},
+		Route{
+			Name:    "ListRunningTasks",
+			Method:  "GET",
+			Pattern: "/api/v1/task",
+			Handler: h.ListRunningTasks(api.V1),
+		},
+		Route{
+			Name:    "Version",
+			Method:  "GET",
+			Pattern: "/api/v1/version",
+			Handler: h.Version(conf, api.V1),
+		},
+	}
+}

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -128,7 +128,7 @@
 .uri .field input,
 .ports .field input,
 .ports .field select,
-.slave_constraints .field input {
+.agent_constraints .field input {
   width: auto !important;
 }
 

--- a/server/static/js/eremetic.js
+++ b/server/static/js/eremetic.js
@@ -27,8 +27,8 @@ $(document).ready(function() {
       }, {});
     }
 
-    if (typeof json.slave_constraints !== "undefined") {
-      json.slave_constraints = json.slave_constraints.reduce(function(collector, element) {
+    if (typeof json.agent_constraints !== "undefined") {
+      json.agent_constraints = json.agent_constraints.reduce(function(collector, element) {
         collector.push({ 'attribute_name': element.attribute_name, 'attribute_value': element.attribute_value });
         return collector;
       }, []);
@@ -41,8 +41,8 @@ $(document).ready(function() {
       }, []);
     }
 
-    json.task_cpus = parseFloat(json.task_cpus);
-    json.task_mem = parseFloat(json.task_mem);
+    json.cpu = parseFloat(json.cpu);
+    json.mem = parseFloat(json.mem);
 
     return json;
   }
@@ -68,7 +68,7 @@ $(document).ready(function() {
 
     $.ajax({
       method: 'POST',
-      url: EREMETIC_URL_PREFIX + '/task',
+      url: EREMETIC_URL_PREFIX + '/api/v1/task',
       data: JSON.stringify(json),
       contentType: 'application/json',
       dataType: 'json',
@@ -94,14 +94,14 @@ $(document).ready(function() {
           placeholder: 'value'
         }
       }
-    } else if (type === 'slave_constraints') {
+    } else if (type === 'agent_constraints') {
       input = {
         one: {
-          name: 'slave_constraints['+number+'][attribute_name]',
+          name: 'agent_constraints['+number+'][attribute_name]',
           placeholder: 'Attribute Name'
         },
         two: {
-          name: 'slave_constraints['+number+'][attribute_value]',
+          name: 'agent_constraints['+number+'][attribute_value]',
           placeholder: 'Attribute Value'
         }
       }
@@ -216,10 +216,10 @@ $(document).ready(function() {
 
   }
 
-  function addSlaveConstraints(e) {
-    var   $cont = $('#slave_constraints')
+  function addAgentConstraints(e) {
+    var   $cont = $('#agent_constraints')
         , index = $cont.data('count') + 1
-        , $input = createInput('slave_constraints', index)
+        , $input = createInput('agent_constraints', index)
         ;
 
     e.preventDefault();
@@ -240,7 +240,7 @@ $(document).ready(function() {
   $('#new_task #ports .plus').on('click', addPorts);
   $('#new_task #env .plus').on('click', addEnvironments);
   $('#new_task #uris .plus').on('click', addURIs);
-  $('#new_task #slave_constraints .plus').on('click', addSlaveConstraints);
+  $('#new_task #agent_constraints .plus').on('click', addAgentConstraints);
   $('#new_task #cancel').on('click', function(e) {
     e.preventDefault();
     window.location = window.location;

--- a/server/static/js/task_view.js
+++ b/server/static/js/task_view.js
@@ -34,7 +34,7 @@ $(document).ready(function() {
     }
     $.ajax({
       method: 'GET',
-      url: EREMETIC_URL_PREFIX + '/task/' + taskId + '/' + logfile,
+      url: EREMETIC_URL_PREFIX + '/api/v1/task/' + taskId + '/' + logfile,
       success: function(data) {
         if (typeof data === 'undefined') {
           return
@@ -62,7 +62,7 @@ $(document).ready(function() {
     e.preventDefault();
     $.ajax({
       method: 'POST',
-      url: EREMETIC_URL_PREFIX + '/task/' + taskId + '/kill',
+      url: EREMETIC_URL_PREFIX + '/api/v1/task/' + taskId + '/kill',
       success: function() {
         window.location = window.location;
       },

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -31,8 +31,8 @@
                 <div class="field">
                   <div class="two fields">
                     <div class="ui icon input field labeled">
-                      <div class="ui label">Container</div>
-                      <input name="docker_image" required="required" type="text" placeholder="busybox" autofocus="autofocus">
+                      <div class="ui label">Image</div>
+                      <input name="image" required="required" type="text" placeholder="busybox" autofocus="autofocus">
                       <i class="docker blue icon"></i>
                     </div>
                     <div class="ui icon input field labeled">
@@ -46,12 +46,12 @@
                   <div class="two fields">
                     <div class="ui icon input field labeled">
                       <div class="ui label">CPUs</div>
-                      <input name="task_cpus" required="required" type="number" placeholder="0" value="1.0" min="0.0" step="0.1">
+                      <input name="cpu" required="required" type="number" placeholder="0" value="1.0" min="0.0" step="0.1">
                       <i class="ui cpu icon svg"></i>
                     </div>
                     <div class="ui icon input field labeled">
                       <div class="ui label">Memory (MiB)</div>
-                      <input name="task_mem" required="required" type="number" placeholder="0" value="100" min="0.0" step="1">
+                      <input name="mem" required="required" type="number" placeholder="0" value="100" min="0.0" step="1">
                       <i class="ui ram icon svg"></i>
                     </div>
                   </div>
@@ -90,7 +90,7 @@
                         <i class="plus icon green add"></i>
                       </label>
                     </div>
-                    <div class="field" id="slave_constraints" data-count=0>
+                    <div class="field" id="agent_constraints" data-count=0>
                       <label>
                         Agent Constraints
                         <i class="plus icon green add"></i>

--- a/server/templates/task.html
+++ b/server/templates/task.html
@@ -91,7 +91,7 @@
                         </div>
                         {{end}}
                         {{if .AgentID}}
-                        <div class="item" title="slave id">
+                        <div class="item" title="agent id">
                             <i class="child icon"></i>
                             <div class="content">
                                 {{.AgentID}}
@@ -111,7 +111,7 @@
                             </div>
                         </div>
                         {{if .AgentConstraints}}
-                            <div class="item" title="slave constraints">
+                            <div class="item" title="agent constraints">
                                 <i class="lock icon"></i>
                                 <div class="content">
                                     <strong>Agent constraints:</strong>

--- a/task.go
+++ b/task.go
@@ -78,37 +78,38 @@ type URI struct {
 	Cache      bool   `json:"cache"`
 }
 
-// Task defines the properties of a scheduled task.
+// Task represents the internal structure of a Task objert
 type Task struct {
-	TaskCPUs          float64           `json:"task_cpus"`
-	TaskMem           float64           `json:"task_mem"`
-	Command           string            `json:"command"`
-	Args              []string          `json:"args"`
-	User              string            `json:"user"`
-	Environment       map[string]string `json:"env"`
-	MaskedEnvironment map[string]string `json:"masked_env"`
-	Image             string            `json:"image"`
-	Volumes           []Volume          `json:"volumes"`
-	Ports             []Port            `json:"ports"`
-	Status            []Status          `json:"status"`
-	ID                string            `json:"id"`
-	Name              string            `json:"name"`
-	Network           string            `json:"network"`
-	DNS               string            `json:"dns"`
-	FrameworkID       string            `json:"framework_id"`
-	AgentID           string            `json:"slave_id"`
-	AgentConstraints  []AgentConstraint `json:"slave_constraints"`
-	Hostname          string            `json:"hostname"`
-	Retry             int               `json:"retry"`
-	CallbackURI       string            `json:"callback_uri"`
-	SandboxPath       string            `json:"sandbox_path"`
-	AgentIP           string            `json:"agent_ip"`
-	AgentPort         int32             `json:"agent_port"`
-	ForcePullImage    bool              `json:"force_pull_image"`
-	FetchURIs         []URI             `json:"fetch"`
+	TaskCPUs          float64
+	TaskMem           float64
+	Command           string
+	Args              []string
+	User              string
+	Environment       map[string]string
+	MaskedEnvironment map[string]string
+	Image             string
+	Volumes           []Volume
+	Ports             []Port
+	Status            []Status
+	ID                string
+	Name              string
+	Network           string
+	DNS               string
+	FrameworkID       string
+	AgentID           string
+	AgentConstraints  []AgentConstraint
+	Hostname          string
+	Retry             int
+	CallbackURI       string
+	SandboxPath       string
+	AgentIP           string
+	AgentPort         int32
+	ForcePullImage    bool
+	FetchURIs         []URI
 }
 
-func isArchive(url string) bool {
+// IsArchive is used to determine whether a url is an archive or not
+func IsArchive(url string) bool {
 	var archiveSfx = []string{".tgz", ".tar.gz", ".tbz2", ".tar.bz2", ".txz", ".tar.xz", ".zip"}
 	for _, s := range archiveSfx {
 		if strings.HasSuffix(url, s) {
@@ -123,7 +124,7 @@ func mergeURIs(request Request) []URI {
 	for _, v := range request.URIs {
 		URIs = append(URIs, URI{
 			URI:        v,
-			Extract:    isArchive(v),
+			Extract:    IsArchive(v),
 			Cache:      false,
 			Executable: false,
 		})
@@ -139,24 +140,24 @@ func mergeURIs(request Request) []URI {
 	return URIs
 }
 
-// Request represents the structure of a job request
+// Request is the internal structure of a Request
 type Request struct {
-	TaskCPUs          float64           `json:"task_cpus"`
-	TaskMem           float64           `json:"task_mem"`
-	DockerImage       string            `json:"docker_image"`
-	Command           string            `json:"command"`
-	Args              []string          `json:"args"`
-	Volumes           []Volume          `json:"volumes"`
-	Ports             []Port            `json:"ports"`
-	Network           string            `json:"network"`
-	DNS               string            `json:"dns"`
-	Environment       map[string]string `json:"env"`
-	MaskedEnvironment map[string]string `json:"masked_env"`
-	AgentConstraints  []AgentConstraint `json:"slave_constraints"`
-	CallbackURI       string            `json:"callback_uri"`
-	URIs              []string          `json:"uris"`
-	Fetch             []URI             `json:"fetch"`
-	ForcePullImage    bool              `json:"force_pull_image"`
+	TaskCPUs          float64
+	TaskMem           float64
+	DockerImage       string
+	Command           string
+	Args              []string
+	Volumes           []Volume
+	Ports             []Port
+	Network           string
+	DNS               string
+	Environment       map[string]string
+	MaskedEnvironment map[string]string
+	AgentConstraints  []AgentConstraint
+	CallbackURI       string
+	URIs              []string
+	Fetch             []URI
+	ForcePullImage    bool
 }
 
 // NewTask returns a new instance of a Task.
@@ -213,10 +214,12 @@ func (task *Task) IsTerminated() bool {
 	return IsTerminal(st)
 }
 
+// IsWaiting returns whether a task is waiting
 func (task *Task) IsWaiting() bool {
 	return task.CurrentStatus() == TaskQueued
 }
 
+// IsTerminating returns whether a task is in the process of terminating
 func (task *Task) IsTerminating() bool {
 	return task.CurrentStatus() == TaskTerminating
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 var (
-	// Version contains the Eremetic application version
-	Version = ""
+	// Version contains the Eremetic application version. Overridden at compile-time by make
+	Version = "0.0.0+devel"
 	// BuildDate contains the date of the build
 	BuildDate = ""
 )


### PR DESCRIPTION
All existing endpoints available under both `/api/v1/task/` and the old `/tasks` endpoint.

# New endpoint
Use agent_* for requests and responses to new routes instead of slave_*
Only JSON responses

# Existing endpoint changes
Add Warning header with Deprecation information to old routes

# Question
Should API change more while we're at it?