### PR TITLE
Add support to filter tasks by name and list terminated tasks

### DIFF
--- a/boltdb/boltdb.go
+++ b/boltdb/boltdb.go
@@ -141,9 +141,8 @@ func (db *TaskDB) DeleteTask(id string) error {
 	})
 }
 
-// ListNonTerminalTasks returns a list of tasks that are not yet finished in one
-// way or another.
-func (db *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
+// ListTasks returns all tasks.
+func (db *TaskDB) ListTasks(filter *eremetic.TaskFilter) ([]*eremetic.Task, error) {
 	tasks := []*eremetic.Task{}
 
 	err := db.conn.View(func(tx *bolt.Tx) error {
@@ -154,8 +153,8 @@ func (db *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 		b.ForEach(func(_, v []byte) error {
 			var task eremetic.Task
 			json.Unmarshal(v, &task)
-			if !task.IsTerminated() {
-				eremetic.ApplyMask(&task)
+			eremetic.ApplyMask(&task)
+			if filter.Match(&task) {
 				tasks = append(tasks, &task)
 			}
 			return nil

--- a/database.go
+++ b/database.go
@@ -30,7 +30,7 @@ type TaskDB interface {
 	ReadTask(id string) (Task, error)
 	DeleteTask(id string) error
 	ReadUnmaskedTask(id string) (Task, error)
-	ListNonTerminalTasks() ([]*Task, error)
+	ListTasks(filter *TaskFilter) ([]*Task, error)
 }
 
 // DefaultTaskDB is a in-memory implementation of TaskDB.
@@ -97,13 +97,13 @@ func (db *DefaultTaskDB) ReadUnmaskedTask(id string) (Task, error) {
 	return Task{}, errors.New("unknown task")
 }
 
-// ListNonTerminalTasks returns all non-terminal tasks.
-func (db *DefaultTaskDB) ListNonTerminalTasks() ([]*Task, error) {
+// ListTasks returns all tasks based on the filter.
+func (db *DefaultTaskDB) ListTasks(filter *TaskFilter) ([]*Task, error) {
 	db.mtx.RLock()
 	defer db.mtx.RUnlock()
 	res := []*Task{}
 	for _, t := range db.tasks {
-		if !t.IsTerminated() {
+		if filter.Match(t) {
 			res = append(res, t)
 		}
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,16 @@
-hash: dac76020cdc6cff763dbf9ade0dddbf94ed3e132b61a292a62fbdd1ff386c18b
-updated: 2017-06-18T15:06:21.53177475+02:00
+hash: bd13dc7ea5b901780c1d2e11f706b427f9dad56aca17cad813642f3db62001cd
+updated: 2017-11-09T18:10:47.535160345+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
 - name: github.com/boltdb/bolt
-  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
+  version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
 - name: github.com/braintree/manners
   version: 0b5e6b2c2843f4c83c2a40f96980b09cf4af733c
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/elazarl/go-bindata-assetfs
@@ -22,13 +22,15 @@ imports:
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/protobuf
-  version: e325f446bebc2998605911c0a2650d9920361d4a
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
   - proto
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: bcd8bc72b08df0f70df986b97f95590779502d31
+- name: github.com/gorilla/schema
+  version: e6c82218a8b3ed3cbeb5407429849c0b0b597d40
 - name: github.com/jacobsa/oglematchers
   version: 141901ea67cd4769c6800aa7bfdfc558fa22bda5
 - name: github.com/kardianos/osext
@@ -72,21 +74,21 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 0d0c3d572886e0f2323ed376557f9eb99b97d25b
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a3bfc74126ea9e45ee5d5c6f7fc86191b7d488fb
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/samuel/go-zookeeper
-  version: 1d7be4effb13d2d908342d349d71a284a7542693
+  version: 9a96098268ef555eb1f04d8b1ee813d0a87e5089
   subpackages:
   - zk
 - name: github.com/Sirupsen/logrus
-  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
@@ -94,30 +96,35 @@ imports:
   subpackages:
   - assert
   - mock
+- name: golang.org/x/crypto
+  version: 6a293f2d4b14b8e6d3f0539e383f6d0d30fce3fd
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
-  version: 973f3f3bbd50e92b13faa6c53ec16f49b45e851c
+  version: a337091b0525af65de94df2eb7e98bd9962dcbe2
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: fb4cac33e3196ff7f507ab9b2d2a44b0142f5b5a
+  version: 4b45465282a4624cf39876842a017334f13b8aff
   subpackages:
   - unix
+  - windows
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports:
 - name: github.com/gopherjs/gopherjs
-  version: dc374d32704510cb387457180ca9d5193978b555
+  version: 444abdf920945de5d4a977b572bcc6c674d1e4eb
   subpackages:
   - js
 - name: github.com/jtolds/gls
   version: 77f18212c9c7edc9bd6a33d383a7b545ce62f064
 - name: github.com/smartystreets/assertions
-  version: 4ea54c1f28ad3ae597e76607dea3871fa177e263
+  version: 0b37b35ec7434b77e77a4bb29b79677cced992ea
   subpackages:
   - internal/go-render/render
   - internal/oglematchers
 - name: github.com/smartystreets/goconvey
-  version: d4c757aa9afd1e2fc1832aaab209b5794eb336e1
+  version: 9e8dc3f972df6c8fcc0375ef492c24d0bb204857
   subpackages:
   - convey
   - convey/gotest

--- a/glide.yaml
+++ b/glide.yaml
@@ -44,6 +44,7 @@ import:
   subpackages:
   - context
 - package: gopkg.in/yaml.v2
+- package: github.com/gorilla/schema
 testImport:
 - package: github.com/smartystreets/goconvey
   version: ~1.6.2

--- a/mesos/reconcile.go
+++ b/mesos/reconcile.go
@@ -34,7 +34,9 @@ func reconcileTasks(driver mesossched.SchedulerDriver, database eremetic.TaskDB)
 			delay = 1
 		)
 
-		tasks, err := database.ListNonTerminalTasks()
+		tasks, err := database.ListTasks(&eremetic.TaskFilter{
+			State: eremetic.DefaultTaskFilterState,
+		})
 		if err != nil {
 			logrus.WithError(err).Error("Failed to list non-terminal tasks")
 			close(done)

--- a/mesos/scheduler.go
+++ b/mesos/scheduler.go
@@ -377,7 +377,7 @@ func (s *Scheduler) Kill(taskId string) error {
 		return fmt.Errorf("You can not kill that which is already dead.")
 	}
 
-	waiting := task.IsWaiting()
+	waiting := task.IsEnqueued()
 
 	logrus.Debugf("Marking task for killing.")
 	task.UpdateStatus(eremetic.Status{

--- a/misc/swagger.yaml
+++ b/misc/swagger.yaml
@@ -14,6 +14,21 @@ paths:
       summary: List running tasks
       description: |
         List all running tasks, masking values in MaskedEnvironment.
+      parameters:
+        - in: query
+          name: name
+          schema:
+            type: string
+          required: false
+          description: The name of the task. There can be several tasks with same name.
+        - in: query
+          name: state
+          schema:
+            type: string
+          required: false
+          description: The state of the task. Valid states are queued, active and terminated.
+           Can be comma combined composite state e.g. "terminated,queued". The Default value
+           is "active,queued". Empty string will return all states.
       responses:
         200:
           description: Task details

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -34,6 +34,7 @@ type TaskDB struct {
 	ReadUnmaskedTaskFn     func(string) (eremetic.Task, error)
 	DeleteTaskFn           func(string) error
 	ListNonTerminalTasksFn func() ([]*eremetic.Task, error)
+	ListTasksFn            func(*eremetic.TaskFilter) ([]*eremetic.Task, error)
 }
 
 // Clean invokes the CleanFn function.
@@ -69,6 +70,11 @@ func (db *TaskDB) DeleteTask(id string) error {
 // ListNonTerminalTasks invokes the ListNonTerminalTasksFn function.
 func (db *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 	return db.ListNonTerminalTasksFn()
+}
+
+// ListTasks invokes the ListTasksFn function.
+func (db *TaskDB) ListTasks(filter *eremetic.TaskFilter) ([]*eremetic.Task, error) {
+	return db.ListTasksFn(filter)
 }
 
 // ErrScheduler mocks the eremetic scheduler.

--- a/server/routes_v0.go
+++ b/server/routes_v0.go
@@ -47,7 +47,7 @@ func apiV0Routes(h Handler, conf *config.Config) Routes {
 			Name:    "ListRunningTasks",
 			Method:  "GET",
 			Pattern: "/task",
-			Handler: h.ListRunningTasks(api.V0),
+			Handler: h.ListTasks(api.V0),
 		},
 		Route{
 			Name:    "Version",

--- a/server/routes_v1.go
+++ b/server/routes_v1.go
@@ -47,7 +47,7 @@ func apiV1Routes(h Handler, conf *config.Config) Routes {
 			Name:    "ListRunningTasks",
 			Method:  "GET",
 			Pattern: "/api/v1/task",
-			Handler: h.ListRunningTasks(api.V1),
+			Handler: h.ListTasks(api.V1),
 		},
 		Route{
 			Name:    "Version",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -195,7 +195,7 @@ func TestServer(t *testing.T) {
 				sched := mock.Scheduler{}
 
 				db := mock.TaskDB{
-					ListNonTerminalTasksFn: func() ([]*eremetic.Task, error) {
+					ListTasksFn: func(filter *eremetic.TaskFilter) ([]*eremetic.Task, error) {
 						return []*eremetic.Task{}, nil
 					},
 				}

--- a/zk/zookeeper.go
+++ b/zk/zookeeper.go
@@ -167,8 +167,8 @@ func (z *TaskDB) DeleteTask(id string) error {
 	return err
 }
 
-// ListNonTerminalTasks returns all non-terminal tasks.
-func (z *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
+// ListTasks returns all tasks.
+func (z *TaskDB) ListTasks(filter *eremetic.TaskFilter) ([]*eremetic.Task, error) {
 	tasks := []*eremetic.Task{}
 	paths, _, _ := z.conn.Children(z.path)
 	for _, p := range paths {
@@ -177,11 +177,10 @@ func (z *TaskDB) ListNonTerminalTasks() ([]*eremetic.Task, error) {
 			logrus.WithError(err).Error("Unable to read task from database, skipping")
 			continue
 		}
-		if !t.IsTerminated() {
-			eremetic.ApplyMask(&t)
+		eremetic.ApplyMask(&t)
+		if filter.Match(&t) {
 			tasks = append(tasks, &t)
 		}
 	}
-
 	return tasks, nil
 }


### PR DESCRIPTION
Second part of #184

Basically this PR allows to filter tasks using query params like `/api/v1/task?name=foo` or `/api/v1/task?state=terminated`

`state` query param can be composite states like `state=terminated,queued` or state=`active,queued` that is by default filter.

I have already added this to enable us for future extensions. So adding a new query param is basically adding a field to `TaskFilter` and changing the `Match` method.

Moreover passing the `TaskFilter` to `db` methods for any future query optimisation any db can do.