### PR TITLE
Framework/mesos auto-reconnect

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,7 @@ func DefaultConfig() *Config {
 		Checkpoint:      true,
 		FailoverTimeout: 2592000.0,
 		QueueSize:       100,
+		FrameworkID:     "1234",
 	}
 }
 

--- a/mesos/scheduler.go
+++ b/mesos/scheduler.go
@@ -131,7 +131,18 @@ func (s *Scheduler) Reregistered(driver mesossched.SchedulerDriver, masterInfo *
 
 // Disconnected is called when the Scheduler is Disconnected
 func (s *Scheduler) Disconnected(mesossched.SchedulerDriver) {
-	logrus.Debugf("Framework disconnected with master")
+	logrus.Debugf("Framework disconnected with master, attempting to connect a new driver")
+	driver, err := createDriver(s, s.settings)
+	s.driver = driver
+
+	if err != nil {
+		logrus.WithError(err).Error("Unable to create scheduler driver")
+	}
+
+	go func() {
+		<-s.shutdown
+		driver.Stop(false)
+	}()
 }
 
 // ResourceOffers handles the Resource Offers


### PR DESCRIPTION
Adding default frameworkID to scheduler config, adding automatic reconnect for framework/mesos disconnect. 

Tested in Rockerbox prod environment, behaves as expected (logs below):

`ERROR: logging before flag.Parse: I0201 21:08:12.343410       1 scheduler.go:419] New master master@<> detected
time="2022-02-01T21:08:12Z" level=debug msg="Framework disconnected with master, attempting to connect a new driver"
time="2022-02-01T21:08:12Z" level=debug msg="No credentials specified in configuration"
ERROR: logging before flag.Parse: I0201 21:08:12.344904       1 scheduler.go:334] Initializing mesos scheduler driver
ERROR: logging before flag.Parse: I0201 21:08:12.677563       1 scheduler.go:583] Framework registered with ID=1234`